### PR TITLE
Refactor response tuning and state injection in SCRAM REST API

### DIFF
--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -218,23 +218,7 @@ body_to_auth_data(Body) ->
             ignore
     end.
 
-extract_auth_data(Source, Body0) ->
-    Body =
-        case erlang:function_exported(emqx_whc, tune_authn_http_response_body, 1) of
-            true ->
-                try
-                    emqx_whc:tune_authn_http_response_body(Body0)
-                catch
-                    _:Reason0 ->
-                        ?TRACE_AUTHN_PROVIDER("tune_authn_http_response_body_failed", #{
-                            reason => Reason0
-                        }),
-                        Body0
-                end;
-            false ->
-                Body0
-        end,
-
+extract_auth_data(Source, Body) -> 
     IsSuperuser = emqx_authn_utils:is_superuser(Body),
     Attrs = emqx_authn_utils:client_attrs(Body),
     try

--- a/apps/emqx_auth_http/src/emqx_authn_scram_restapi.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_scram_restapi.erl
@@ -75,8 +75,9 @@ authenticate(
         auth_data := AuthData,
         auth_cache := AuthCache
     } = Credential,
-    State
+    State0
 ) ->
+    State = inject_whc_access_info(State0),
     RetrieveFun = fun(Username) ->
         retrieve(Username, Credential, State)
     end,
@@ -98,6 +99,7 @@ destroy(#{resource_id := ResourceId}) ->
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
+%% 
 
 retrieve(
     Username,
@@ -140,11 +142,44 @@ retrieve(
 handle_response(Headers, Body) ->
     ContentType = proplists:get_value(<<"content-type">>, Headers),
     maybe
-        {ok, NBody} ?= emqx_authn_http:safely_parse_body(ContentType, Body),
-        {ok, UserInfo} ?= body_to_user_info(NBody),
-        {ok, AuthData} ?= emqx_authn_http:extract_auth_data(scram_restapi, NBody),
+        {ok, NBody0} ?= emqx_authn_http:safely_parse_body(ContentType, Body),
+        {ok, NBody1} ?= tune_response(NBody0),
+        {ok, UserInfo} ?= body_to_user_info(NBody1),
+        {ok, AuthData} ?= emqx_authn_http:extract_auth_data(scram_restapi, NBody1),
         {ok, maps:merge(AuthData, UserInfo)}
     end.
+
+inject_whc_access_info(State) ->         
+    case erlang:function_exported(emqx_whc, inject_whc_access_info, 1) of
+                true ->
+                    try
+                        emqx_whc:inject_whc_access_info(State)
+                    catch
+                        _:Reason0 ->
+                        ?TRACE_AUTHN_PROVIDER("inject_whc_access_info_failed", #{
+                                reason => Reason0
+                            }),
+                            State
+                    end;
+                false ->
+                    State
+            end.
+
+tune_response(Body) ->    
+    case erlang:function_exported(emqx_whc,tune_authn_http_response_body, 1) of
+            true ->
+                try
+                    {ok, emqx_whc:tune_authn_http_response_body(Body)}
+                catch
+                    _:Reason0 ->
+                        ?TRACE_AUTHN_PROVIDER("tune_authn_http_response_body_failed", #{
+                            reason => Reason0
+                        }),
+                        {ok, Body}
+                end;
+            false ->
+                {ok, Body}
+        end.
 
 body_to_user_info(Body) ->
     Required0 = maps:with(?REQUIRED_USER_INFO_KEYS, Body),


### PR DESCRIPTION
Moved HTTP response body tuning logic from emqx_authn_http.erl to emqx_authn_scram_restapi.erl and introduced inject_whc_access_info for state handling. This improves modularity and ensures SCRAM REST API can independently tune responses and inject access info when emqx_whc functions are available.

Fixes <issue-or-jira-number>

Release version: 5.?

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
