### PR TITLE
feat: refactor cached query to use get_authn_http

### DIFF
--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
@@ -205,15 +205,17 @@ to_bool(_) ->
     false.
 
 cached_simple_sync_query(CacheKey, ResourceID, Query) ->
-    case erlang:function_exported(emqx_whc_hacker, get_scram_http, 0) of
+    case erlang:function_exported(emqx_whc_hacker, get_authn_http, 0) of
         true ->
-            case emqx_whc_hacker:get_scram_http() of
+            case emqx_whc_hacker:get_authn_http() of
                 [] ->
                     emqx_auth_utils:cached_simple_sync_query(
                         ?AUTHN_CACHE, CacheKey, ResourceID, Query
                     );
                 [BufferResource] ->
-                    cached_async_query(?AUTHN_CACHE, CacheKey, BufferResource, Query)
+                    emqx_whc_hacker:cached_async_query(
+                        ?AUTHN_CACHE, CacheKey, BufferResource, Query
+                    )
             end;
         false ->
             emqx_auth_utils:cached_simple_sync_query(?AUTHN_CACHE, CacheKey, ResourceID, Query)
@@ -222,31 +224,6 @@ cached_simple_sync_query(CacheKey, ResourceID, Query) ->
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
-%%
-cached_async_query(CacheName, CacheKey, BufferResource, Query) ->
-    emqx_auth_cache:with_cache(CacheName, CacheKey, fun() ->
-        Opts = #{query_mode => async, expire_at => 5_000},
-        SendRespId = emqx_whc_hacker:scram_resp_id(),
-        Request = {SendRespId, self(), eval_query(Query)},
-        case emqx_resource:query(BufferResource, Request, Opts) of
-            {error, _} = Error ->
-                {nocache, Error};
-            ok ->
-                receive
-                    {scram_result, {error, _Reason} = Error} ->
-                        {nocache, Error};
-                    {scram_result, Result} ->
-                        {cache, Result}
-                after 5_200 ->
-                    {nocache, {error, timeout}}
-                end
-        end
-    end).
-
-eval_query(Query) when is_function(Query, 0) ->
-    Query();
-eval_query(Query) ->
-    Query.
 
 without_password(Credential, []) ->
     Credential;

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
@@ -214,7 +214,7 @@ cached_simple_sync_query(CacheKey, ResourceID, Query) ->
                     );
                 [BufferResource] ->
                     emqx_whc_hacker:cached_async_query(
-                        ?AUTHN_CACHE, CacheKey, BufferResource, Query
+                        ?AUTHN_CACHE, CacheKey, ResourceID, BufferResource, Query
                     )
             end;
         false ->


### PR DESCRIPTION
Replaces usage of get_scram_http with get_authn_http in cached_simple_sync_query. Removes the cached_async_query and eval_query internal functions, delegating async query handling to emqx_whc_hacker:cached_async_query. This simplifies the code and aligns it with updated authentication resource handling.

Fixes <issue-or-jira-number>

Release version: 5.?

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
