### PR TITLE
feat(kafka-consumer): inject traceparent into MQTT user properties

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
@@ -29,7 +29,8 @@
 -ifdef(TEST).
 -export([
     consumer_group_id/2,
-    mqtt_headers_from_kafka_headers/1
+    mqtt_headers_from_kafka_headers/1,
+    build_legacy_mqtt_message/5
 ]).
 -endif.
 
@@ -348,17 +349,20 @@ legacy_maybe_publish_mqtt_message(
     Payload = render(FullMessage, PayloadTemplate),
     MQTTTopic = render(FullMessage, MQTTTopicTemplate),
     MQTTHeaders = mqtt_headers_from_kafka_headers(maps:get(headers, FullMessage, #{})),
-    MQTTMessage =
-        case MQTTHeaders of
-            #{} ->
-                emqx_message:make(SourceResId, MQTTQoS, MQTTTopic, Payload);
-            _ ->
-                emqx_message:make(SourceResId, MQTTQoS, MQTTTopic, Payload, #{}, MQTTHeaders)
-        end,
+    MQTTMessage = build_legacy_mqtt_message(SourceResId, MQTTQoS, MQTTTopic, Payload, MQTTHeaders),
     _ = emqx_broker:safe_publish(MQTTMessage),
     ok;
 legacy_maybe_publish_mqtt_message(_MQTTConfig, _SourceResId, _FullMessage) ->
     ok.
+
+build_legacy_mqtt_message(SourceResId, MQTTQoS, MQTTTopic, Payload, MQTTHeaders)
+  when is_map(MQTTHeaders) ->
+    case map_size(MQTTHeaders) of
+        0 ->
+            emqx_message:make(SourceResId, MQTTQoS, MQTTTopic, Payload);
+        _ ->
+            emqx_message:make(SourceResId, MQTTQoS, MQTTTopic, Payload, #{}, MQTTHeaders)
+    end.
 
 %%-------------------------------------------------------------------------------------
 %% Helper fns

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
@@ -27,7 +27,10 @@
 ]).
 
 -ifdef(TEST).
--export([consumer_group_id/2]).
+-export([
+    consumer_group_id/2,
+    mqtt_headers_from_kafka_headers/1
+]).
 -endif.
 
 -include_lib("emqx/include/logger.hrl").
@@ -344,7 +347,14 @@ legacy_maybe_publish_mqtt_message(
 ) when MQTTTopicTemplate =/= <<>> ->
     Payload = render(FullMessage, PayloadTemplate),
     MQTTTopic = render(FullMessage, MQTTTopicTemplate),
-    MQTTMessage = emqx_message:make(SourceResId, MQTTQoS, MQTTTopic, Payload),
+    MQTTHeaders = mqtt_headers_from_kafka_headers(maps:get(headers, FullMessage, #{})),
+    MQTTMessage =
+        case MQTTHeaders of
+            #{} ->
+                emqx_message:make(SourceResId, MQTTQoS, MQTTTopic, Payload);
+            _ ->
+                emqx_message:make(SourceResId, MQTTQoS, MQTTTopic, Payload, #{}, MQTTHeaders)
+        end,
     _ = emqx_broker:safe_publish(MQTTMessage),
     ok;
 legacy_maybe_publish_mqtt_message(_MQTTConfig, _SourceResId, _FullMessage) ->
@@ -731,6 +741,66 @@ render(FullMessage, PayloadTemplate) ->
         end
     },
     emqx_placeholder:proc_tmpl(PayloadTemplate, FullMessage, Opts).
+
+mqtt_headers_from_kafka_headers(Headers) when is_map(Headers) ->
+    case find_traceparent_header(Headers) of
+        undefined ->
+            #{};
+        Traceparent ->
+            #{
+                properties => #{
+                    'User-Property' => [{<<"traceparent">>, Traceparent}]
+                }
+            }
+    end;
+mqtt_headers_from_kafka_headers(_) ->
+    #{}.
+
+find_traceparent_header(Headers) ->
+    maps:fold(
+        fun(Key, Value, Acc) ->
+            case Acc of
+                undefined ->
+                    case is_traceparent_key(Key) of
+                        true ->
+                            normalize_traceparent(Value);
+                        false ->
+                            undefined
+                    end;
+                _ ->
+                    Acc
+            end
+        end,
+        undefined,
+        Headers
+    ).
+
+is_traceparent_key(Key) when is_binary(Key) ->
+    to_lower_bin(Key) =:= <<"traceparent">>;
+is_traceparent_key(Key) when is_list(Key) ->
+    is_traceparent_key(iolist_to_binary(Key));
+is_traceparent_key(Key) when is_atom(Key) ->
+    is_traceparent_key(atom_to_binary(Key, utf8));
+is_traceparent_key(_) ->
+    false.
+
+normalize_traceparent(Value) when is_binary(Value), byte_size(Value) > 0 ->
+    Value;
+normalize_traceparent(Value) when is_list(Value) ->
+    Bin = iolist_to_binary(Value),
+    normalize_traceparent(Bin);
+normalize_traceparent(Value) when is_atom(Value) ->
+    normalize_traceparent(atom_to_binary(Value, utf8));
+normalize_traceparent(_) ->
+    undefined.
+
+to_lower_bin(Bin) when is_binary(Bin) ->
+    <<<<(to_lower_char(C))>> || <<C>> <= Bin>>.
+
+to_lower_char(C) when C >= $A, C =< $Z ->
+    C + 32;
+to_lower_char(C) ->
+    C.
 
 encode(Value, none) ->
     Value;

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_tests.erl
@@ -36,3 +36,30 @@ traceparent_absent_test() ->
         #{},
         emqx_bridge_kafka_impl_consumer:mqtt_headers_from_kafka_headers(#{<<"k">> => <<"v">>})
     ).
+
+legacy_mqtt_message_with_headers_test() ->
+    Traceparent = <<"00-11111111111111111111111111111111-2222222222222222-01">>,
+    Headers = #{
+        properties => #{
+            'User-Property' => [{<<"traceparent">>, Traceparent}]
+        }
+    },
+    Msg = emqx_bridge_kafka_impl_consumer:build_legacy_mqtt_message(
+        <<"source:kafka_consumer:test">>,
+        1,
+        <<"/t">>,
+        <<"p">>,
+        Headers
+    ),
+    Props = emqx_message:get_header(properties, Msg, #{}),
+    ?assertEqual([{<<"traceparent">>, Traceparent}], maps:get('User-Property', Props, [])).
+
+legacy_mqtt_message_without_headers_test() ->
+    Msg = emqx_bridge_kafka_impl_consumer:build_legacy_mqtt_message(
+        <<"source:kafka_consumer:test">>,
+        1,
+        <<"/t">>,
+        <<"p">>,
+        #{}
+    ),
+    ?assertEqual(#{}, emqx_message:get_header(properties, Msg, #{})).

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_tests.erl
@@ -1,0 +1,38 @@
+-module(emqx_bridge_kafka_impl_consumer_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+traceparent_injection_test() ->
+    Traceparent = <<"00-4bf92f3577b34da6a3ce929d0e0e4736-a3ce929d0e0e4736-01">>,
+    Headers = emqx_bridge_kafka_impl_consumer:mqtt_headers_from_kafka_headers(#{
+        <<"traceparent">> => Traceparent,
+        <<"other">> => <<"value">>
+    }),
+    ?assertEqual(
+        #{
+            properties => #{
+                'User-Property' => [{<<"traceparent">>, Traceparent}]
+            }
+        },
+        Headers
+    ).
+
+traceparent_case_insensitive_injection_test() ->
+    Traceparent = <<"00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01">>,
+    Headers = emqx_bridge_kafka_impl_consumer:mqtt_headers_from_kafka_headers(#{
+        <<"TraceParent">> => Traceparent
+    }),
+    ?assertEqual(
+        #{
+            properties => #{
+                'User-Property' => [{<<"traceparent">>, Traceparent}]
+            }
+        },
+        Headers
+    ).
+
+traceparent_absent_test() ->
+    ?assertEqual(
+        #{},
+        emqx_bridge_kafka_impl_consumer:mqtt_headers_from_kafka_headers(#{<<"k">> => <<"v">>})
+    ).


### PR DESCRIPTION
## Summary
- inject Kafka header `traceparent` into MQTT v5 `User-Property` for kafka_consumer messages
- keep existing consumer flow unchanged when header is absent
- add eunit coverage for injected / absent / case-insensitive key paths

## Validation
- `rebar3 as test compile`
- `rebar3 as test eunit --app emqx_bridge_kafka --module emqx_bridge_kafka_impl_consumer_tests`
