### PR TITLE
feat: prioritize quick uplink publish in mixed incoming batches

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -763,19 +763,17 @@ is_quick_uplink_publish_packet(_) ->
     false.
 
 is_quick_uplink_topic(Topic) when is_binary(Topic) ->
-    TopicSegments = lists:reverse(binary:split(Topic, <<"/">>, [global, trim_all])),
-    is_quick_uplink_topic_segments(TopicSegments);
+    has_binary_suffix(Topic, <<"/quick/datas">>) orelse
+        has_binary_suffix(Topic, <<"/quickdatas">>) orelse
+        has_binary_suffix(Topic, <<"/quickevents">>);
 is_quick_uplink_topic(_) ->
     false.
 
-is_quick_uplink_topic_segments([<<"datas">>, <<"quick">> | _]) ->
-    true;
-is_quick_uplink_topic_segments([<<"quickdatas">> | _]) ->
-    true;
-is_quick_uplink_topic_segments([<<"quickevents">> | _]) ->
-    true;
-is_quick_uplink_topic_segments(_) ->
-    false.
+has_binary_suffix(Topic, Suffix) ->
+    TopicSize = byte_size(Topic),
+    SuffixSize = byte_size(Suffix),
+    TopicSize >= SuffixSize andalso
+        binary:part(Topic, TopicSize - SuffixSize, SuffixSize) =:= Suffix.
 
 parse_incoming(Data, State = #state{parser = Parser}) ->
     try

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -739,13 +739,43 @@ on_bytes_in(Oct, Data, State) ->
     {Packets, NState} = parse_incoming(Data, State),
     {ok, next_incoming_msgs(Packets), NState}.
 
-%% @doc: return a reversed Msg list
+%% @doc Return incoming messages in processing order.
+%% Parser output list is reversed, so we restore network order first.
+%% Quick uplink PUBLISH packets are moved ahead to reduce end-to-end latency.
 -compile({inline, [next_incoming_msgs/1]}).
 next_incoming_msgs([Packet]) ->
     {incoming, Packet};
 next_incoming_msgs(Packets) ->
-    Fun = fun(Packet, Acc) -> [{incoming, Packet} | Acc] end,
-    lists:foldl(Fun, [], Packets).
+    OrderedPackets = lists:reverse(Packets),
+    PrioritizedPackets = prioritize_quick_uplink_publish_packets(OrderedPackets),
+    [{incoming, Packet} || Packet <- PrioritizedPackets].
+
+prioritize_quick_uplink_publish_packets(Packets) ->
+    {QuickPackets, NormalPackets} = lists:partition(
+        fun is_quick_uplink_publish_packet/1,
+        Packets
+    ),
+    QuickPackets ++ NormalPackets.
+
+is_quick_uplink_publish_packet(#mqtt_packet{variable = #mqtt_packet_publish{topic_name = Topic}}) ->
+    is_quick_uplink_topic(Topic);
+is_quick_uplink_publish_packet(_) ->
+    false.
+
+is_quick_uplink_topic(Topic) when is_binary(Topic) ->
+    TopicSegments = lists:reverse(binary:split(Topic, <<"/">>, [global, trim_all])),
+    is_quick_uplink_topic_segments(TopicSegments);
+is_quick_uplink_topic(_) ->
+    false.
+
+is_quick_uplink_topic_segments([<<"datas">>, <<"quick">> | _]) ->
+    true;
+is_quick_uplink_topic_segments([<<"quickdatas">> | _]) ->
+    true;
+is_quick_uplink_topic_segments([<<"quickevents">> | _]) ->
+    true;
+is_quick_uplink_topic_segments(_) ->
+    false.
 
 parse_incoming(Data, State = #state{parser = Parser}) ->
     try

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -230,6 +230,39 @@ t_handle_msg_deliver(_) ->
     ok = meck:expect(emqx_channel, handle_deliver, fun(_, Channel) -> {ok, Channel} end),
     ?assertMatch({ok, _St}, handle_msg({deliver, topic, msg}, st())).
 
+t_next_incoming_msgs_prioritize_quick_uplink_publish(_) ->
+    %% Parse output is reversed list; original network order assumed:
+    %% 1) normal datas, 2) quick datas.
+    Normal = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/datas">>, 1, <<"n">>),
+    Quick = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/quick/datas">>, 2, <<"q">>),
+    ParseOutputReversed = [Quick, Normal],
+    ?assertEqual(
+        [{incoming, Quick}, {incoming, Normal}],
+        emqx_connection:next_incoming_msgs(ParseOutputReversed)
+    ).
+
+t_next_incoming_msgs_prioritize_quick_uplink_topic_variants(_) ->
+    %% Original network order: quickdatas, normal datas, quickevents.
+    QuickDatas = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/quickdatas">>, 1, <<"qd">>),
+    Normal = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/datas">>, 2, <<"n">>),
+    QuickEvents = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/quickevents">>, 3, <<"qe">>),
+    ParseOutputReversed = [QuickEvents, Normal, QuickDatas],
+    ?assertEqual(
+        [{incoming, QuickDatas}, {incoming, QuickEvents}, {incoming, Normal}],
+        emqx_connection:next_incoming_msgs(ParseOutputReversed)
+    ).
+
+t_next_incoming_msgs_prioritize_quick_publish_when_mixed_packets(_) ->
+    %% Mixed batch: quick publish is moved to the head.
+    P1 = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/datas">>, 1, <<"p1">>),
+    P2 = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/quick/datas">>, 2, <<"p2">>),
+    Ping = ?PACKET(?PINGREQ),
+    ParseOutputReversed = [P2, Ping, P1],
+    ?assertEqual(
+        [{incoming, P2}, {incoming, P1}, {incoming, Ping}],
+        emqx_connection:next_incoming_msgs(ParseOutputReversed)
+    ).
+
 t_handle_msg_inet_reply(_) ->
     ?assertMatch(
         {stop, {shutdown, for_testing}, _St},

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -263,6 +263,18 @@ t_next_incoming_msgs_prioritize_quick_publish_when_mixed_packets(_) ->
         emqx_connection:next_incoming_msgs(ParseOutputReversed)
     ).
 
+t_next_incoming_msgs_prioritize_multiple_quick_publish_when_mixed_packets(_) ->
+    %% Multiple quick publish packets keep FIFO while moving ahead.
+    Normal = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/datas">>, 1, <<"n">>),
+    Quick1 = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/quick/datas">>, 2, <<"q1">>),
+    Ping = ?PACKET(?PINGREQ),
+    Quick2 = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/quickevents">>, 3, <<"q2">>),
+    ParseOutputReversed = [Quick2, Ping, Quick1, Normal],
+    ?assertEqual(
+        [{incoming, Quick1}, {incoming, Quick2}, {incoming, Normal}, {incoming, Ping}],
+        emqx_connection:next_incoming_msgs(ParseOutputReversed)
+    ).
+
 t_handle_msg_inet_reply(_) ->
     ?assertMatch(
         {stop, {shutdown, for_testing}, _St},

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -252,6 +252,16 @@ t_next_incoming_msgs_prioritize_quick_uplink_topic_variants(_) ->
         emqx_connection:next_incoming_msgs(ParseOutputReversed)
     ).
 
+t_next_incoming_msgs_do_not_prioritize_non_exact_quick_like_topic(_) ->
+    %% Non-exact topic (double slash) should not be treated as quick uplink topic.
+    Normal = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/datas">>, 1, <<"n">>),
+    QuickLike = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/quick//datas">>, 2, <<"q">>),
+    ParseOutputReversed = [QuickLike, Normal],
+    ?assertEqual(
+        [{incoming, Normal}, {incoming, QuickLike}],
+        emqx_connection:next_incoming_msgs(ParseOutputReversed)
+    ).
+
 t_next_incoming_msgs_prioritize_quick_publish_when_mixed_packets(_) ->
     %% Mixed batch: quick publish is moved to the head.
     P1 = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/datas">>, 1, <<"p1">>),
@@ -260,6 +270,17 @@ t_next_incoming_msgs_prioritize_quick_publish_when_mixed_packets(_) ->
     ParseOutputReversed = [P2, Ping, P1],
     ?assertEqual(
         [{incoming, P2}, {incoming, P1}, {incoming, Ping}],
+        emqx_connection:next_incoming_msgs(ParseOutputReversed)
+    ).
+
+t_next_incoming_msgs_prioritize_quick_publish_before_disconnect_in_mixed_packets(_) ->
+    %% Keep requested behavior: quick publish can move ahead of DISCONNECT in same batch.
+    Normal = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/datas">>, 1, <<"n">>),
+    Disconnect = ?DISCONNECT_PACKET(),
+    Quick = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/quick/datas">>, 2, <<"q">>),
+    ParseOutputReversed = [Quick, Disconnect, Normal],
+    ?assertEqual(
+        [{incoming, Quick}, {incoming, Normal}, {incoming, Disconnect}],
         emqx_connection:next_incoming_msgs(ParseOutputReversed)
     ).
 


### PR DESCRIPTION
Fixes N/A (WHC custom enhancement)

Release version: 5.10.1 (WHC custom branch)

## Summary

This PR adjusts incoming batch packet ordering so that quick uplink PUBLISH messages are always handled first, including when control packets are mixed in the same parser batch.

### What changed

1. `apps/emqx/src/emqx_connection.erl`
   - Updated `next_incoming_msgs/1` flow to:
     - restore natural parser order (`lists:reverse/1`), then
     - prioritize quick uplink publishes to the head of processing list.
   - Priority now applies for **mixed batches** too.
   - **Intentional semantic change:** in mixed batches, quick uplink publish can be processed before control packets from the same parser batch.
   - Quick uplink topic recognition remains scoped to:
     - `/quick/datas`
     - `/quickdatas`
     - `/quickevents`

2. `apps/emqx/test/emqx_connection_SUITE.erl`
   - Added/updated tests for:
     - quick publish prioritized for regular all-publish batch
     - quick topic variants (`quickdatas`, `quickevents`)
     - mixed batch behavior: quick publish is moved ahead of non-quick publish and control packet
     - mixed batch with multiple quick publishes: quick group and non-quick group both keep FIFO

### Why

For WHC uplink traffic, quick telemetry/event topics are latency-sensitive. Prioritizing these packets earlier in connection-level incoming handling reduces queueing delay under mixed traffic.

## Validation

Executed locally:
- `make emqx-enterprise-compile`
- `make ct-suite SUITE=apps/emqx/test/emqx_connection_SUITE.erl TESTCASE=t_next_incoming_msgs_prioritize_quick_uplink_publish PROFILE=emqx-enterprise`
  - blocked by local environment conflict: `tcp:default ... eaddrinuse` on `0.0.0.0:1883`
- Direct function-level verification (compiled test beam):
  - `t_next_incoming_msgs_prioritize_quick_uplink_publish/1`
  - `t_next_incoming_msgs_prioritize_quick_uplink_topic_variants/1`
  - `t_next_incoming_msgs_prioritize_quick_publish_when_mixed_packets/1`
  - `t_next_incoming_msgs_prioritize_multiple_quick_publish_when_mixed_packets/1`
  - `t_next_incoming_msgs/1`

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
