### PR TITLE
refactor: hardcode WHC quick-topic callbacks in core

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -124,8 +124,6 @@
 -opaque state() :: #state{}.
 
 -define(ACTIVE_N, 10).
--define(PT_QUICK_UPLINK_TOPIC_MATCH_MFA, {emqx_whc_hacker, quick_uplink_topic_match_mfa}).
-
 -define(INFO_KEYS, [
     socktype,
     peername,
@@ -768,23 +766,22 @@ is_quick_uplink_publish_packet(_) ->
     false.
 
 is_quick_uplink_topic(Topic) when is_binary(Topic) ->
-    do_is_quick_uplink_topic(
-        Topic, persistent_term:get(?PT_QUICK_UPLINK_TOPIC_MATCH_MFA, undefined)
-    );
+    do_is_quick_uplink_topic(Topic);
 is_quick_uplink_topic(_) ->
     false.
 
-do_is_quick_uplink_topic(Topic, {Module, Function, Args}) when
-    is_atom(Module), is_atom(Function), is_list(Args)
-->
-    try erlang:apply(Module, Function, [Topic | Args]) of
-        true -> true;
-        _ -> false
-    catch
-        _:_ -> false
-    end;
-do_is_quick_uplink_topic(_Topic, _) ->
-    false.
+do_is_quick_uplink_topic(Topic) ->
+    case erlang:function_exported(emqx_whc_hacker, is_quick_uplink_topic, 1) of
+        true ->
+            try emqx_whc_hacker:is_quick_uplink_topic(Topic) of
+                true -> true;
+                _ -> false
+            catch
+                _:_ -> false
+            end;
+        false ->
+            false
+    end.
 
 parse_incoming(Data, State = #state{parser = Parser}) ->
     try

--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -61,8 +61,6 @@
 ]).
 
 -define(NO_PRIORITY_TABLE, disabled).
--define(PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA, {emqx_whc_hacker, quick_downlink_topic_match_mfa}).
-
 -export_type([mqueue/0, options/0]).
 
 -type priority() :: infinity | integer().
@@ -340,23 +338,22 @@ get_priority(Topic, PTab, Dp) ->
     maps:get(Topic, PTab, Dp).
 
 is_quick_downlink_topic(Topic) when is_binary(Topic) ->
-    do_is_quick_downlink_topic(
-        Topic, persistent_term:get(?PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA, undefined)
-    );
+    do_is_quick_downlink_topic(Topic);
 is_quick_downlink_topic(_) ->
     false.
 
-do_is_quick_downlink_topic(Topic, {Module, Function, Args}) when
-    is_atom(Module), is_atom(Function), is_list(Args)
-->
-    try erlang:apply(Module, Function, [Topic | Args]) of
-        true -> true;
-        _ -> false
-    catch
-        _:_ -> false
-    end;
-do_is_quick_downlink_topic(_Topic, _) ->
-    false.
+do_is_quick_downlink_topic(Topic) ->
+    case erlang:function_exported(emqx_whc_hacker, is_quick_downlink_topic, 1) of
+        true ->
+            try emqx_whc_hacker:is_quick_downlink_topic(Topic) of
+                true -> true;
+                _ -> false
+            catch
+                _:_ -> false
+            end;
+        false ->
+            false
+    end.
 
 get_credits(?HIGHEST_PRIORITY, Opts) ->
     Infinity = 1000000,

--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -61,6 +61,7 @@
 ]).
 
 -define(NO_PRIORITY_TABLE, disabled).
+-define(PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA, {emqx_whc_hacker, quick_downlink_topic_match_mfa}).
 
 -export_type([mqueue/0, options/0]).
 
@@ -330,8 +331,32 @@ get_priority_opt(Opts) ->
 %% disregard default priority from config, always use lowest (?LOWEST_PRIORITY=0)
 %% because the lowest priority in emqx_pqueue is a fallback to queue:queue()
 %% while the highest 'infinity' is a [{infinity, queue:queue()}]
-get_priority(_Topic, ?NO_PRIORITY_TABLE, _) -> ?LOWEST_PRIORITY;
-get_priority(Topic, PTab, Dp) -> maps:get(Topic, PTab, Dp).
+get_priority(Topic, ?NO_PRIORITY_TABLE, _) ->
+    case is_quick_downlink_topic(Topic) of
+        true -> ?HIGHEST_PRIORITY;
+        false -> ?LOWEST_PRIORITY
+    end;
+get_priority(Topic, PTab, Dp) ->
+    maps:get(Topic, PTab, Dp).
+
+is_quick_downlink_topic(Topic) when is_binary(Topic) ->
+    do_is_quick_downlink_topic(
+        Topic, persistent_term:get(?PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA, undefined)
+    );
+is_quick_downlink_topic(_) ->
+    false.
+
+do_is_quick_downlink_topic(Topic, {Module, Function, Args}) when
+    is_atom(Module), is_atom(Function), is_list(Args)
+->
+    try erlang:apply(Module, Function, [Topic | Args]) of
+        true -> true;
+        _ -> false
+    catch
+        _:_ -> false
+    end;
+do_is_quick_downlink_topic(_Topic, _) ->
+    false.
 
 get_credits(?HIGHEST_PRIORITY, Opts) ->
     Infinity = 1000000,

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -11,8 +11,6 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--define(PT_QUICK_UPLINK_TOPIC_MATCH_MFA, {emqx_whc_hacker, quick_uplink_topic_match_mfa}).
-
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 %%--------------------------------------------------------------------
@@ -48,11 +46,10 @@ init_per_suite(Config) ->
     ok = meck:expect(emqx_alarm, deactivate, fun(_) -> ok end),
     ok = meck:expect(emqx_alarm, deactivate, fun(_, _) -> ok end),
 
+    ok = meck:new(emqx_whc_hacker, [non_strict, no_history, no_link]),
+    ok = meck:expect(emqx_whc_hacker, is_quick_uplink_topic, fun is_default_quick_uplink_topic/1),
+
     Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
-    persistent_term:put(
-        ?PT_QUICK_UPLINK_TOPIC_MATCH_MFA,
-        {?MODULE, is_default_quick_uplink_topic, []}
-    ),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
@@ -63,7 +60,7 @@ end_per_suite(Config) ->
     ok = meck:unload(emqx_metrics),
     ok = meck:unload(emqx_hooks),
     ok = meck:unload(emqx_alarm),
-    persistent_term:erase(?PT_QUICK_UPLINK_TOPIC_MATCH_MFA),
+    ok = meck:unload(emqx_whc_hacker),
 
     emqx_cth_suite:stop(proplists:get_value(apps, Config)).
 
@@ -307,19 +304,15 @@ t_next_incoming_msgs_use_mfa_callback(_) ->
     Normal = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/datas">>, 1, <<"n">>),
     Fast = ?PUBLISH_PACKET(?QOS_1, <<"/v1/devices/gw-1/fast">>, 2, <<"f">>),
     ParseOutputReversed = [Fast, Normal],
-    persistent_term:put(
-        ?PT_QUICK_UPLINK_TOPIC_MATCH_MFA,
-        {?MODULE, is_fast_uplink_topic, []}
-    ),
+    ok = meck:expect(emqx_whc_hacker, is_quick_uplink_topic, fun is_fast_uplink_topic/1),
     try
         ?assertEqual(
             [{incoming, Fast}, {incoming, Normal}],
             emqx_connection:next_incoming_msgs(ParseOutputReversed)
         )
     after
-        persistent_term:put(
-            ?PT_QUICK_UPLINK_TOPIC_MATCH_MFA,
-            {?MODULE, is_default_quick_uplink_topic, []}
+        ok = meck:expect(
+            emqx_whc_hacker, is_quick_uplink_topic, fun is_default_quick_uplink_topic/1
         )
     end.
 

--- a/apps/emqx/test/emqx_mqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_mqueue_SUITE.erl
@@ -14,6 +14,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(Q, emqx_mqueue).
+-define(PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA, {emqx_whc_hacker, quick_downlink_topic_match_mfa}).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -118,6 +119,27 @@ t_priority_mqueue(_) ->
     ?assertEqual(5, ?Q:len(Q6)),
     {{value, _Msg}, Q7} = ?Q:out(Q6),
     ?assertEqual(4, ?Q:len(Q7)).
+
+t_dynamic_quick_downlink_priority_mqueue(_) ->
+    restore_pt(
+        ?PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA,
+        fun() ->
+            persistent_term:put(
+                ?PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA,
+                {?MODULE, is_quick_downlink_topic, []}
+            ),
+            Q0 = ?Q:init(#{max_len => 10, store_qos0 => false}),
+            {_, Q1} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/command">>}, Q0),
+            {_, Q2} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/quickcommand">>}, Q1),
+            {_, Q3} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/command">>}, Q2),
+            {{value, M1}, Q4} = ?Q:out(Q3),
+            {{value, M2}, Q5} = ?Q:out(Q4),
+            {{value, M3}, _Q6} = ?Q:out(Q5),
+            ?assertEqual(<<"/v1/devices/gw-1/quickcommand">>, M1#message.topic),
+            ?assertEqual(<<"/v1/devices/gw-1/command">>, M2#message.topic),
+            ?assertEqual(<<"/v1/devices/gw-1/command">>, M3#message.topic)
+        end
+    ).
 
 t_priority_mqueue_conservation(_) ->
     true = proper:quickcheck(conservation_prop()).
@@ -503,3 +525,24 @@ mqueue_prio(#message{extra = #{mqueue_priority := Prio}}) -> Prio.
 
 with_empty_extra(Msgs) ->
     [M#message{extra = #{}} || M <- Msgs].
+
+is_quick_downlink_topic(Topic) when is_binary(Topic) ->
+    case binary:match(Topic, <<"/quickcommand">>) of
+        nomatch -> false;
+        _ -> true
+    end;
+is_quick_downlink_topic(_) ->
+    false.
+
+restore_pt(Key, Fun) ->
+    OldValue = persistent_term:get(Key, undefined),
+    try
+        Fun()
+    after
+        case OldValue of
+            undefined ->
+                persistent_term:erase(Key);
+            _ ->
+                persistent_term:put(Key, OldValue)
+        end
+    end.

--- a/apps/emqx/test/emqx_mqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_mqueue_SUITE.erl
@@ -14,7 +14,6 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(Q, emqx_mqueue).
--define(PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA, {emqx_whc_hacker, quick_downlink_topic_match_mfa}).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -121,25 +120,22 @@ t_priority_mqueue(_) ->
     ?assertEqual(4, ?Q:len(Q7)).
 
 t_dynamic_quick_downlink_priority_mqueue(_) ->
-    restore_pt(
-        ?PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA,
-        fun() ->
-            persistent_term:put(
-                ?PT_QUICK_DOWNLINK_TOPIC_MATCH_MFA,
-                {?MODULE, is_quick_downlink_topic, []}
-            ),
-            Q0 = ?Q:init(#{max_len => 10, store_qos0 => false}),
-            {_, Q1} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/command">>}, Q0),
-            {_, Q2} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/quickcommand">>}, Q1),
-            {_, Q3} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/command">>}, Q2),
-            {{value, M1}, Q4} = ?Q:out(Q3),
-            {{value, M2}, Q5} = ?Q:out(Q4),
-            {{value, M3}, _Q6} = ?Q:out(Q5),
-            ?assertEqual(<<"/v1/devices/gw-1/quickcommand">>, M1#message.topic),
-            ?assertEqual(<<"/v1/devices/gw-1/command">>, M2#message.topic),
-            ?assertEqual(<<"/v1/devices/gw-1/command">>, M3#message.topic)
-        end
-    ).
+    ok = meck:new(emqx_whc_hacker, [non_strict, no_history, no_link]),
+    ok = meck:expect(emqx_whc_hacker, is_quick_downlink_topic, fun is_quick_downlink_topic/1),
+    try
+        Q0 = ?Q:init(#{max_len => 10, store_qos0 => false}),
+        {_, Q1} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/command">>}, Q0),
+        {_, Q2} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/quickcommand">>}, Q1),
+        {_, Q3} = ?Q:in(#message{qos = 1, topic = <<"/v1/devices/gw-1/command">>}, Q2),
+        {{value, M1}, Q4} = ?Q:out(Q3),
+        {{value, M2}, Q5} = ?Q:out(Q4),
+        {{value, M3}, _Q6} = ?Q:out(Q5),
+        ?assertEqual(<<"/v1/devices/gw-1/quickcommand">>, M1#message.topic),
+        ?assertEqual(<<"/v1/devices/gw-1/command">>, M2#message.topic),
+        ?assertEqual(<<"/v1/devices/gw-1/command">>, M3#message.topic)
+    after
+        meck:unload(emqx_whc_hacker)
+    end.
 
 t_priority_mqueue_conservation(_) ->
     true = proper:quickcheck(conservation_prop()).
@@ -533,16 +529,3 @@ is_quick_downlink_topic(Topic) when is_binary(Topic) ->
     end;
 is_quick_downlink_topic(_) ->
     false.
-
-restore_pt(Key, Fun) ->
-    OldValue = persistent_term:get(Key, undefined),
-    try
-        Fun()
-    after
-        case OldValue of
-            undefined ->
-                persistent_term:erase(Key);
-            _ ->
-                persistent_term:put(Key, OldValue)
-        end
-    end.

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -13,7 +13,6 @@
 -compile(nowarn_export_all).
 
 -define(ws_conn, emqx_ws_connection).
--define(PT_QUICK_UPLINK_TOPIC_MATCH_MFA, {emqx_whc_hacker, quick_uplink_topic_match_mfa}).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -343,11 +342,8 @@ t_websocket_incoming(_) ->
     ?assertEqual(<<"invalid_property_code">>, CauseReq).
 
 t_handle_incoming_prioritize_quick_publish_by_mfa(_) ->
-    PrevMFA = persistent_term:get(?PT_QUICK_UPLINK_TOPIC_MATCH_MFA, undefined),
-    persistent_term:put(
-        ?PT_QUICK_UPLINK_TOPIC_MATCH_MFA,
-        {?MODULE, is_fast_uplink_topic, []}
-    ),
+    ok = meck:new(emqx_whc_hacker, [non_strict, no_history, no_link]),
+    ok = meck:expect(emqx_whc_hacker, is_quick_uplink_topic, fun is_fast_uplink_topic/1),
     ok = meck:new(emqx_channel, [passthrough, no_history, no_link]),
     ok = meck:expect(emqx_channel, handle_in, fun(Packet, Channel) ->
         Handled0 =
@@ -367,12 +363,7 @@ t_handle_incoming_prioritize_quick_publish_by_mfa(_) ->
     after
         erlang:erase(handled_packets),
         meck:unload(emqx_channel),
-        case PrevMFA of
-            undefined ->
-                persistent_term:erase(?PT_QUICK_UPLINK_TOPIC_MATCH_MFA);
-            MFA ->
-                persistent_term:put(?PT_QUICK_UPLINK_TOPIC_MATCH_MFA, MFA)
-        end
+        meck:unload(emqx_whc_hacker)
     end.
 
 t_websocket_info_check_gc(_) ->


### PR DESCRIPTION
## Summary

This PR updates message-priority callback integration to match the WHC patching style:

- **Remove `persistent_term` MFA indirection** from quick-topic matching in EMQX core.
- **Use hardcoded callback module/function** (`emqx_whc_hacker`) with exported-function existence check.
- If callback exists and returns `true`, apply quick priority behavior; otherwise fallback to original behavior.

## Changes

1. `apps/emqx/src/emqx_connection.erl`
   - `is_quick_uplink_topic/1` now calls hardcoded `emqx_whc_hacker:is_quick_uplink_topic/1`.
   - Guarded by `erlang:function_exported/3` and `try/catch` fallback.

2. `apps/emqx/src/emqx_mqueue.erl`
   - `is_quick_downlink_topic/1` now calls hardcoded `emqx_whc_hacker:is_quick_downlink_topic/1`.
   - Guarded by `erlang:function_exported/3` and `try/catch` fallback.

3. Test updates
   - `apps/emqx/test/emqx_connection_SUITE.erl`
   - `apps/emqx/test/emqx_ws_connection_SUITE.erl`
   - `apps/emqx/test/emqx_mqueue_SUITE.erl`
   - Replace previous `persistent_term`-based test setup with `meck` on `emqx_whc_hacker` callbacks.

## Validation

- `make fmt-diff`
- `make ct-suite SUITE=apps/emqx/test/emqx_mqueue_SUITE.erl TESTCASE=t_dynamic_quick_downlink_priority_mqueue PROFILE=emqx-enterprise` ✅
- `make ct-suite SUITE=apps/emqx/test/emqx_connection_SUITE.erl TESTCASE=t_next_incoming_msgs_use_mfa_callback PROFILE=emqx-enterprise` ✅
- `make ct-suite SUITE=apps/emqx/test/emqx_ws_connection_SUITE.erl TESTCASE=t_handle_incoming_prioritize_quick_publish_by_mfa PROFILE=emqx-enterprise` ✅

